### PR TITLE
Sensible default for outputPublicPath

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,8 @@ module.exports = function(htmlFileContent) {
 
     const outputPath = parsedQuery.outputPath == null
         ? this.options.output.path
-        : parsedQuery.outputPath
-
+        : '/'
+    
     const outputPublicPath = parsedQuery.outputPublicPath == null
         ? this.options.output.publicPath
         : parsedQuery.outputPublicPath


### PR DESCRIPTION
I am not at all a webpack expert, so this change may not be appropriate. However when writing my own config, I did not need a public path, default being '/'.
So I think we should rely on this default when computing the component path (but once again I am not a webpack expert).